### PR TITLE
SAM-120: Enables filtering by custom user-defined fields

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,13 @@
 # sample_search_api release notes
 =========================================
 
+0.1.0
+-----
+* Adding get_sampleset_meta method to get sample field names from given list of sample ids
+* Adding support for filtering by custom user-defined fields
+* Adding "any" type for user-defined fields that will attempt to parse field to correct type without
+validation schema needed
+
 0.0.2
 -----
 * Changing filter generation to support terms with colons (":") in them. i.e. `sesar:term`

--- a/lib/sample_search_api/sample_search_apiImpl.py
+++ b/lib/sample_search_api/sample_search_apiImpl.py
@@ -43,7 +43,7 @@ more complex lexicographical queries (nested or parenthesis)
         self.sample_url = config.get('kbase-endpoint') + '/sampleservice'
         self.shared_folder = config['scratch']
         self.sample_service = SampleService(self.sample_url)
-        self.meta_manager = MetadataManager(config.get('re-admin-token'), re_api_url)
+        self.meta_manager = MetadataManager(re_api_url, re_admin_token=config.get('re-admin-token'))
         self.sample_filter = SampleFilterer(config.get('re-admin-token'), re_api_url,
                                             self.sample_service)
         logging.basicConfig(format='%(created)s %(levelname)s: %(message)s',

--- a/lib/sample_search_api/sample_search_apiImpl.py
+++ b/lib/sample_search_api/sample_search_apiImpl.py
@@ -43,7 +43,8 @@ more complex lexicographical queries (nested or parenthesis)
         self.sample_url = config.get('kbase-endpoint') + '/sampleservice'
         self.shared_folder = config['scratch']
         self.sample_service = SampleService(self.sample_url)
-        self.meta_manager = MetadataManager(re_api_url, re_admin_token=config.get('re-admin-token'))
+        self.meta_manager = MetadataManager(re_api_url,
+                                            re_admin_token=config.get('re-admin-token'))
         self.sample_filter = SampleFilterer(config.get('re-admin-token'), re_api_url,
                                             self.sample_service)
         logging.basicConfig(format='%(created)s %(levelname)s: %(message)s',

--- a/lib/utils/filter_samples.py
+++ b/lib/utils/filter_samples.py
@@ -152,7 +152,7 @@ class SampleFilterer():
         formatted_filters = []
         for idx, parsed_filter in enumerate(parsed_filters):
             if parsed_filter.get('field', '').startswith('custom:'):
-                stat_meta = {'type': 'any'} # no validation for uncontrolled fields
+                stat_meta = {'type': 'any'}  # no validation for uncontrolled fields
             else:
                 stat_meta = static_metadata.get(parsed_filter.get('field'))
             formatted_filters.append(

--- a/lib/utils/filter_samples.py
+++ b/lib/utils/filter_samples.py
@@ -6,8 +6,10 @@ from utils.parsing_and_formatting import (
     parse_values,
     parse_comparison_operator,
     parse_logical_operator,
-    field_value_formatting
+    field_value_formatting,
+    partition_controlled_parsed_filters
 )
+from utils.meta_manager import MetadataManager
 
 SAMPLE_NODE_COLLECTION = "samples_nodes"
 SAMPLE_SAMPLE_COLLECTION = "samples_sample"
@@ -28,7 +30,7 @@ let node_metas = (for version_id in version_ids
     for node in {SAMPLE_NODE_COLLECTION}
         FILTER node.id == version_id.id and node.uuidver == version_id.version_id
         LIMIT @num_sample_ids
-        let meta_objs_values = (for meta in node.cmeta
+        let meta_objs_values = (for meta in APPEND(node.cmeta, node.ucmeta)
             RETURN {{ [ meta.ok ]: {{ [ meta.k ]: meta.v }} }}
         )
         RETURN {{
@@ -61,7 +63,10 @@ class SampleFilterer():
             'comp_op': parse_comparison_operator(fc.get('comparison_operator'), idx),
             'logic_op': parse_logical_operator(fc.get('logical_operator'), idx, num_filters)
         } for idx, fc in enumerate(filter_conditions)]
-        formatted_filters = self._format_and_validate_filters(parsed_filters)
+
+        # use the user token if an admin token is not provided
+        run_token = self.re_admin_token if self.re_admin_token else user_token
+        formatted_filters = self._format_and_validate_filters(parsed_filters, samples, run_token)
         for idx, formatted_filter in enumerate(formatted_filters):
             query_constraint, filter_params = self._construct_filter(
                 formatted_filter, idx
@@ -77,8 +82,6 @@ class SampleFilterer():
         AQL_query += """
         RETURN {"id": node.id, "version": node.version}
         """
-        # use the user token if an admin token is not provided
-        run_token = self.re_admin_token if self.re_admin_token else user_token
         results = execute_query(
             AQL_query,
             self.re_api_url,
@@ -93,6 +96,9 @@ class SampleFilterer():
             'field', 'comparison_operator', 'value', 'logical_operator'
         '''
         field = formatted_filter.get('field')
+        if 'custom:' in field:
+            # parse out custom: prefix from uncontrolled fields
+            field = field[len("custom:"):]
         comp_op = formatted_filter.get('comp_op')
         values = formatted_filter.get('values')
         AQL_query = f"node.meta['{field}'].value {comp_op} @value{idx}"
@@ -104,15 +110,16 @@ class SampleFilterer():
         }
         return AQL_query, filter_params
 
-    def _format_and_validate_filters(self, parsed_filters):
+    def _format_and_validate_filters(self, parsed_filters, samples, token):
         '''
         The SampleService will error here if the metadata field
         is not found as an accepted controlled metadata field
         '''
+        c_filters, uc_filters = partition_controlled_parsed_filters(parsed_filters)
         try:
             static_metadata = self.sample_service.get_metadata_key_static_metadata({
                 'prefix': 0,  # expects these not to be prefix validated.
-                'keys': set([pf['field'] for pf in parsed_filters])
+                'keys': set([pf['field'] for pf in c_filters])
             })['static_metadata']
         except Exception as error:
             err_message = error.message
@@ -120,7 +127,7 @@ class SampleFilterer():
             try:
                 static_metadata = self.sample_service.get_metadata_key_static_metadata({
                     'prefix': 1,  # assume the ones that failed are prefix validated
-                    'keys': set([pf['field'] for pf in parsed_filters])
+                    'keys': set([pf['field'] for pf in c_filters])
                 })['static_metadata']
             except Exception as error:
                 err_message = error.message
@@ -130,9 +137,24 @@ class SampleFilterer():
                 message = "Unable to resolve metadata fields or prefix metadata fields: " + \
                           ", ".join(list(key_set))
                 raise ValueError(message)
+
+        # check if there are any bad uncontrolled fields
+        if len(uc_filters):
+            fields = MetadataManager(self.re_api_url).get_sampleset_meta(samples, token)['results']
+            uc_fields = {f['field'] for f in uc_filters}
+            missing_fields = uc_fields.difference(set(fields))
+            if len(missing_fields):
+                message = "Unable to resolve uncontrolled custom metadata fields: " + \
+                    ", ".join(list(missing_fields))
+                raise ValueError(message)
+
+
         formatted_filters = []
         for idx, parsed_filter in enumerate(parsed_filters):
-            stat_meta = static_metadata.get(parsed_filter.get('field'))
+            if parsed_filter.get('field', '').startswith('custom:'):
+                stat_meta = {'type': 'any'} # no validation for uncontrolled fields
+            else:
+                stat_meta = static_metadata.get(parsed_filter.get('field'))
             formatted_filters.append(
                 field_value_formatting(parsed_filter, stat_meta, idx)
             )

--- a/lib/utils/meta_manager.py
+++ b/lib/utils/meta_manager.py
@@ -16,18 +16,20 @@ META_AQL_TEMPLATE = f"""
             for node in {SAMPLE_NODE_COLLECTION}
                 FILTER node.id == version_id.id AND node.uuidver == version_id.version_id
                 LIMIT @num_sample_ids
-                let meta_objs_keys = (FOR meta in node.cmeta
+                let cmeta_keys = (FOR meta IN node.cmeta
                     RETURN meta.ok
                 )
-            RETURN meta_objs_keys
+                let ucmeta_keys = (FOR meta IN node.ucmeta
+                    RETURN CONCAT("custom:", meta.ok)
+                )
+            RETURN APPEND(cmeta_keys, ucmeta_keys)
         )
         RETURN UNIQUE(FLATTEN(node_metas))
         """
 
-
 class MetadataManager:
 
-    def __init__(cls, re_admin_token, re_api_url):
+    def __init__(cls, re_api_url, re_admin_token=None):
         cls.re_api_url = re_api_url
         cls.re_admin_token = re_admin_token
 

--- a/lib/utils/parsing_and_formatting.py
+++ b/lib/utils/parsing_and_formatting.py
@@ -8,7 +8,8 @@ ACCEPTED_FIELD_TYPE_OPERATOR_PAIRINGS = {
     'noop': ["==", "!=", "IN", "NOT IN"],
     'enum': ["==", "!=", "IN", "NOT IN"],
     'ontology': ["==", "!=", "IN", "NOT IN"],
-    'any': ["==", "!=", "<", ">", ">=", "<=", "IN", "NOT IN"] # for uncontrolled, unvalidated fields
+    # type 'any' for uncontrolled, unvalidated fields
+    'any': ["==", "!=", "<", ">", ">=", "<=", "IN", "NOT IN"]
 }
 AQL_one_to_many_value_comparison_operators = {"IN", "NOT IN"}
 AQL_single_value_comparison_operators = {"==", "!=", "<", ">", ">=", "<="}
@@ -185,6 +186,7 @@ def parse_logical_operator(logic_op, idx, num_filters):
         raise ValueError(f"Input logical operator in filter condition {idx} must be one of: "
                          ", ".join(["\'" + str(term) + "\'" for term in AQL_logical_operators]))
     return logic_op.upper()
+
 
 def partition_controlled_parsed_filters(parsed_filters):
     # separates out controlled parsed_filters from uncontrolled for validation

--- a/lib/utils/parsing_and_formatting.py
+++ b/lib/utils/parsing_and_formatting.py
@@ -190,7 +190,7 @@ def parse_logical_operator(logic_op, idx, num_filters):
 
 def partition_controlled_parsed_filters(parsed_filters):
     # separates out controlled parsed_filters from uncontrolled for validation
-    uc_filters = [pf for pf in parsed_filters if pf['field'].startswith('custom:')]
-    c_filters = [cf for cf in parsed_filters if cf not in uc_filters]
+    custom_filters = [pf for pf in parsed_filters if pf['field'].startswith('custom:')]
+    controlled_filters = [cf for cf in parsed_filters if cf not in custom_filters]
 
-    return c_filters, uc_filters
+    return controlled_filters, custom_filters

--- a/test/sample_search_api_server_test.py
+++ b/test/sample_search_api_server_test.py
@@ -371,7 +371,7 @@ class sample_search_apiTest(unittest.TestCase):
         results = self.serviceImpl.get_sampleset_meta(self.ctx, params)[0]['results']
 
         self.assertEqual(len(set(results)), len(results))
-        # ensure that there are unconrolled meta keys included 
+        # ensure that there are unconrolled meta keys included
         # (even when not included in all samplesets)
         self.assertIn('custom:hazen_uranium_mg_l', results)
         self.assertEqual(len(results), 62)
@@ -427,7 +427,7 @@ class sample_search_apiTest(unittest.TestCase):
             }
         ]
 
-        # test 2 different types of samplesets for uncontrolled fields 
+        # test 2 different types of samplesets for uncontrolled fields
         # (they should work if theres at least one)
         test_samples = self.valid_enigma_sample_ids + self.valid_sample_ids
 

--- a/test/sample_search_api_server_test.py
+++ b/test/sample_search_api_server_test.py
@@ -371,7 +371,8 @@ class sample_search_apiTest(unittest.TestCase):
         results = self.serviceImpl.get_sampleset_meta(self.ctx, params)[0]['results']
 
         self.assertEqual(len(set(results)), len(results))
-        # ensure that there are unconrolled meta keys included (even when not included in all samplesets)
+        # ensure that there are unconrolled meta keys included 
+        # (even when not included in all samplesets)
         self.assertIn('custom:hazen_uranium_mg_l', results)
         self.assertEqual(len(results), 62)
 
@@ -404,20 +405,37 @@ class sample_search_apiTest(unittest.TestCase):
 
         filters = [
             # controlled field shouldn't throw
-            {'field': 'ph', 'comp_op': '>=', 'values': [7], 'logic_op': 'or'},
+            {
+                'field': 'ph',
+                'comp_op': '>=',
+                'values': [7],
+                'logic_op': 'or'
+            },
             # uncontrolled field that exists so shouldn't throw
-            {'field': 'custom:hazen_uranium_mg_l', 'comp_op': '>', 'values': ['0'], 'logic_op': 'or'},
+            {
+                'field': 'custom:hazen_uranium_mg_l',
+                'comp_op': '>',
+                'values': ['0'],
+                'logic_op': 'or'
+            },
             # field that does not exist on any sampleset should throw
-            {'field': 'custom:AAAAAAA', 'comp_op': '>', 'values': ['0'], 'logic_op': 'or'}
+            {
+                'field': 'custom:AAAAAAA',
+                'comp_op': '>',
+                'values': ['0'],
+                'logic_op': 'or'
+            }
         ]
 
-        # test 2 different types of samplesets for uncontrolled fields (they should work if theres at least one)
+        # test 2 different types of samplesets for uncontrolled fields 
+        # (they should work if theres at least one)
         test_samples = self.valid_enigma_sample_ids + self.valid_sample_ids
 
         with self.assertRaises(ValueError) as context:
             sf._format_and_validate_filters(filters, test_samples, self.ctx['token'])
 
-        self.assertIn('Unable to resolve uncontrolled custom metadata fields:', str(context.exception))
+        self.assertIn('Unable to resolve uncontrolled custom metadata fields:',
+                      str(context.exception))
         self.assertIn('custom:AAAAAAA', str(context.exception))
         self.assertNotIn('custom:hazen_uranium_mg_l', str(context.exception))
         self.assertNotIn('ph', str(context.exception))


### PR DESCRIPTION
* Allows users to filter based on custom metadata fields in the samples they have uploaded
* Adds support for including all custom field names in get_sampleset_meta method
* Creates custom type "any" and separate validation path for user-defined fields with no schema template