### PR TITLE
Use workspace samples meta

### DIFF
--- a/lib/sample_search_api/sample_search_apiImpl.py
+++ b/lib/sample_search_api/sample_search_apiImpl.py
@@ -102,8 +102,8 @@ more complex lexicographical queries (nested or parenthesis)
         This is intended for use in the filter_samplesets dynamic dropdown.
         :param params: instance of type "GetSamplesetMetaParams" ->
            structure: parameter "sample_set_refs" of list of type string.
-        :returns: instance of type "GetSamplesetMetaResults" -> structure:
-           parameter "results" of list of type String
+        :returns: list of type "GetSamplesetMetaResult" -> structure:
+           parameter "field" of type "String"
         """
         # ctx is the context object
         # return variables are: results
@@ -126,7 +126,8 @@ more complex lexicographical queries (nested or parenthesis)
             raise ValueError(
                 f'Invalid sampleset ref - sample in dataset missing the {str(e)} field.'
             )
-        results = self.meta_manager.get_sampleset_meta(sample_ids, ctx.get('token'))
+        fields = self.meta_manager.get_sampleset_meta(sample_ids, ctx.get('token'))
+        results = [{'field': f} for f in fields]
         #END get_sampleset_meta
         # At some point might do deeper type checking...
         if not isinstance(results, list):

--- a/lib/sample_search_api/sample_search_apiImpl.py
+++ b/lib/sample_search_api/sample_search_apiImpl.py
@@ -118,7 +118,7 @@ more complex lexicographical queries (nested or parenthesis)
                 'id': sample['id'],
                 'version': sample['version']
             } for sample in samples]
-        except WorkspaceError as e:
+        except WorkspaceError:
             raise ValueError(
                 f'Bad sampleset ids: {",".join(params.get("sample_set_refs"))}'
             )

--- a/lib/utils/filter_samples.py
+++ b/lib/utils/filter_samples.py
@@ -158,7 +158,7 @@ class SampleFilterer():
     def _validate_custom_fields(self, custom_filters, samples, token):
         # get all samples and search for each field in sampleset
         # if any uncontrolled fields are completely missing from set, throw an error
-        fields = MetadataManager(self.re_api_url).get_sampleset_meta(samples, token)['results']
+        fields = MetadataManager(self.re_api_url).get_sampleset_meta(samples, token)
         uc_fields = {f['field'] for f in custom_filters}
         missing_fields = uc_fields.difference(set(fields))
         if len(missing_fields):

--- a/lib/utils/meta_manager.py
+++ b/lib/utils/meta_manager.py
@@ -37,11 +37,11 @@ class MetadataManager:
         # use the user token if an admin token is not provided
         query_params = {"sample_ids": sample_ids, 'num_sample_ids': len(sample_ids)}
         run_token = self.re_admin_token if self.re_admin_token else user_token
-        results = execute_query(
+        ret = execute_query(
             META_AQL_TEMPLATE,
             self.re_api_url,
             run_token,
             query_params
         )
 
-        return {'results': results['results'][0]}
+        return ret['results'][0]

--- a/sample_search_api.spec
+++ b/sample_search_api.spec
@@ -63,10 +63,14 @@ module sample_search_api {
         list<string> sample_set_refs;
     } GetSamplesetMetaParams;
 
+    typedef structure {
+        string field;
+    } GetSamplesetMetaResult;
+
     /*
     Gets all metadata fields present in a given list of sampleset refs. If samples with different custom fields are
     included, it will return both different fields in an OR style operation. This is intended for use in the 
     filter_samplesets dynamic dropdown.
     */
-    funcdef get_sampleset_meta(GetSamplesetMetaParams params) returns (list<string> results) authentication required;
+    funcdef get_sampleset_meta(GetSamplesetMetaParams params) returns (list<GetSamplesetMetaResult> results) authentication required;
 };

--- a/sample_search_api.spec
+++ b/sample_search_api.spec
@@ -60,18 +60,13 @@ module sample_search_api {
     funcdef filter_samples(FilterSamplesParams params) returns (FilterSamplesResults results) authentication required;
 
     typedef structure {
-        list<SampleAddress> sample_ids;
+        list<string> sample_set_refs;
     } GetSamplesetMetaParams;
 
-    typedef structure {
-        list<string> results;
-    } GetSamplesetMetaResults;
-
-
     /*
-    Gets all metadata fields present in a given list of samples. If samples with different custom fields are
+    Gets all metadata fields present in a given list of sampleset refs. If samples with different custom fields are
     included, it will return both different fields in an OR style operation. This is intended for use in the 
     filter_samplesets dynamic dropdown.
     */
-    funcdef get_sampleset_meta(GetSamplesetMetaParams params) returns (GetSamplesetMetaResults results) authentication required;
+    funcdef get_sampleset_meta(GetSamplesetMetaParams params) returns (list<string> results) authentication required;
 };

--- a/test/sample_search_api_server_test.py
+++ b/test/sample_search_api_server_test.py
@@ -332,15 +332,18 @@ class sample_search_apiTest(unittest.TestCase):
             'sample_set_refs': [self.sampleset_object_ref]
         }
         results = self.serviceImpl.get_sampleset_meta(self.ctx, params)[0]
+        # get list of unique items to compare length
+        result_fields = {f['field'] for f in results}
 
         self.assertIsInstance(results, list)
-        # check that the results are strings
-        self.assertIsInstance(results[0], str)
+        # check that the results are dicts of strings
+        self.assertIsInstance(results[0], dict)
+        self.assertIsInstance(results[0]['field'], str)
         # check that all meta field values are unique
-        self.assertEqual(len(set(results)), len(results))
+        self.assertEqual(len(result_fields), len(results))
 
-        self.assertIn('sesar:igsn', results)
-        self.assertIn('purpose', results)
+        self.assertIn({'field': 'sesar:igsn'}, results)
+        self.assertIn({'field': 'purpose'}, results)
 
     # @unittest.skip('x')
     def test_get_sampleset_meta_uncontrolled_fields(self):
@@ -355,7 +358,7 @@ class sample_search_apiTest(unittest.TestCase):
 
         ret = self.serviceImpl.get_sampleset_meta(self.ctx, params)[0]
 
-        custom_fields = [r for r in ret if r.startswith('custom:')]
+        custom_fields = [r['field'] for r in ret if r['field'].startswith('custom:')]
 
         self.assertEqual(len(ret), 51)
         self.assertEqual(len(custom_fields), 8)
@@ -375,11 +378,13 @@ class sample_search_apiTest(unittest.TestCase):
         }
 
         results = self.serviceImpl.get_sampleset_meta(self.ctx, params)[0]
+        # convert to set
+        result_fields = {r['field'] for r in results}
 
-        self.assertEqual(len(set(results)), len(results))
+        self.assertEqual(len(result_fields), len(results))
         # ensure that there are unconrolled meta keys included
         # (even when not included in all samplesets)
-        self.assertIn('custom:hazen_uranium_mg_l', results)
+        self.assertIn({'field': 'custom:hazen_uranium_mg_l'}, results)
         self.assertEqual(len(results), 69)
 
     def test_filter_samples_with_uncontrolled_fields(self):

--- a/test/sample_search_api_server_test.py
+++ b/test/sample_search_api_server_test.py
@@ -59,6 +59,9 @@ class sample_search_apiTest(unittest.TestCase):
             {'id': 'b969c622-ea18-4dda-9943-bf1692e526dd', 'version': 1}
         ]
 
+        # corresponding sample set object ref for the above samples
+        cls.sampleset_object_ref = '64822/2/1'
+
         # for testing get_sampleset_meta
         cls.valid_enigma_sample_ids = [
             {"id": "cb77625e-e6af-4a1e-846a-71788c66904b", 'version': 1},
@@ -70,6 +73,9 @@ class sample_search_apiTest(unittest.TestCase):
             {"id": "ed967127-5ba5-4ae6-a062-d566973aa9c3", "version": 1},
             {"id": "f02a03a7-0e5f-4517-b859-d6061956784f", "version": 1}
         ]
+
+        # corresponding sampleset object ref for the above enigma samples
+        cls.enigma_object_ref = '65799/3/2'
 
     @classmethod
     def tearDownClass(cls):
@@ -323,9 +329,9 @@ class sample_search_apiTest(unittest.TestCase):
     # @unittest.skip('x')
     def test_get_sampleset_meta(self):
         params = {
-            'sample_ids': self.valid_sample_ids
+            'sample_set_refs': [self.sampleset_object_ref]
         }
-        results = self.serviceImpl.get_sampleset_meta(self.ctx, params)[0]['results']
+        results = self.serviceImpl.get_sampleset_meta(self.ctx, params)[0]
 
         self.assertIsInstance(results, list)
         # check that the results are strings
@@ -344,15 +350,15 @@ class sample_search_apiTest(unittest.TestCase):
         """
 
         params = {
-            'sample_ids': self.valid_enigma_sample_ids
+            'sample_set_refs': [self.enigma_object_ref]
         }
 
-        ret = self.serviceImpl.get_sampleset_meta(self.ctx, params)[0]['results']
+        ret = self.serviceImpl.get_sampleset_meta(self.ctx, params)[0]
 
         custom_fields = [r for r in ret if r.startswith('custom:')]
 
-        self.assertEqual(len(ret), 44)
-        self.assertEqual(len(custom_fields), 6)
+        self.assertEqual(len(ret), 51)
+        self.assertEqual(len(custom_fields), 8)
         self.assertIn('custom:adams_nitrate_um', custom_fields)
         self.assertIn('custom:hazen_n2_mm', custom_fields)
 
@@ -365,16 +371,16 @@ class sample_search_apiTest(unittest.TestCase):
         '''
 
         params = {
-            'sample_ids': self.valid_enigma_sample_ids + self.valid_sample_ids
+            'sample_set_refs': [self.sampleset_object_ref, self.enigma_object_ref]
         }
 
-        results = self.serviceImpl.get_sampleset_meta(self.ctx, params)[0]['results']
+        results = self.serviceImpl.get_sampleset_meta(self.ctx, params)[0]
 
         self.assertEqual(len(set(results)), len(results))
         # ensure that there are unconrolled meta keys included
         # (even when not included in all samplesets)
         self.assertIn('custom:hazen_uranium_mg_l', results)
-        self.assertEqual(len(results), 62)
+        self.assertEqual(len(results), 69)
 
     def test_filter_samples_with_uncontrolled_fields(self):
         params = {


### PR DESCRIPTION
* FIxes issue with going through sample_uploader to get metadata keys
* Uses workspace.get_objects2 to get list of sample ids for getting meta columns
* changes get_sampleset_meta spec params to take list of sampleset refs instead of list of sample ids
* changes get_samplset_meta return type from dict to list<string> so that it can directly populate dynamic dropdown