### PR TITLE
Lookup metadata keys

### DIFF
--- a/test/sample_search_api_server_test.py
+++ b/test/sample_search_api_server_test.py
@@ -101,7 +101,7 @@ class sample_search_apiTest(unittest.TestCase):
         )[0]
         end = time.time()
         self.assertEqual(len(ret['sample_ids']), 7)
-        self.assertEqual(ret['sample_ids'], self.valid_sample_ids)
+        self.assertCountEqual(ret['sample_ids'], self.valid_sample_ids)
 
     # @unittest.skip('x')
     def test_multi_condition_filter_from_same_sample_set(self):
@@ -136,7 +136,7 @@ class sample_search_apiTest(unittest.TestCase):
         )[0]
         end = time.time()
         self.assertEqual(len(ret['sample_ids']), 4)
-        self.assertEqual([{"id": s['id'], "version": s['version']} for s in ret['sample_ids']], [
+        self.assertCountEqual([{"id": s['id'], "version": s['version']} for s in ret['sample_ids']], [
             {'id': 'c9daec72-348e-426b-bef6-04bcdd0e01fa', 'version': 1},
             {'id': 'efffc90e-64bb-48fb-97c9-c2db3f37f7fc', 'version': 1},
             {'id': '3d108e8a-d583-4aa4-a2b8-0ae592abf066', 'version': 1},

--- a/test/sample_search_api_server_test.py
+++ b/test/sample_search_api_server_test.py
@@ -81,7 +81,6 @@ class sample_search_apiTest(unittest.TestCase):
     def tearDownClass(cls):
         if hasattr(cls, 'wsName'):
             cls.wsClient.delete_workspace({'workspace': cls.wsName})
-            print('Test workspace was deleted')
 
     # @unittest.skip('x')
     def test_filter_with_one_condition_and_value_has_whitespace(self):
@@ -103,8 +102,6 @@ class sample_search_apiTest(unittest.TestCase):
         end = time.time()
         self.assertEqual(len(ret['sample_ids']), 7)
         self.assertEqual(ret['sample_ids'], self.valid_sample_ids)
-        print('filter samples test_filter_with_one_condition_and_value_has_whitespace takes '
-              f'{end - start} seconds to run')
 
     # @unittest.skip('x')
     def test_multi_condition_filter_from_same_sample_set(self):
@@ -145,8 +142,6 @@ class sample_search_apiTest(unittest.TestCase):
             {'id': '3d108e8a-d583-4aa4-a2b8-0ae592abf066', 'version': 1},
             {'id': 'b969c622-ea18-4dda-9943-bf1692e526dd', 'version': 1}
         ])
-        print('filter samples test_multi_condition_filter_from_same_sample_set '
-              f'takes {end - start} seconds to run')
 
     # @unittest.skip('x')
     def test_multi_value_filter_condition(self):
@@ -176,8 +171,6 @@ class sample_search_apiTest(unittest.TestCase):
             {'id': '6fc28cbd-39b3-4da6-a928-e56a680111b7', 'version': 1},
             {'id': '3f272ea3-6e52-4e09-b5c5-525217ac5a49', 'version': 1}
         ])
-        print('filter test_multi_value_filter_condition samples '
-              f'takes {end - start} seconds to run')
 
     # @unittest.skip('x')
     def test_not_enough_samples(self):
@@ -399,7 +392,7 @@ class sample_search_apiTest(unittest.TestCase):
         }
         ret = self.serviceImpl.filter_samples(self.ctx, params)
         self.assertEqual(len(ret[0]['sample_ids']), 3)
-        self.assertEqual(ret[0]['sample_ids'], [
+        self.assertCountEqual(ret[0]['sample_ids'], [
             {'id': '26a758a6-2779-425f-a8d0-e9c6276d3b9f', 'version': 1},
             {'id': 'ed967127-5ba5-4ae6-a062-d566973aa9c3', 'version': 1},
             {'id': 'f02a03a7-0e5f-4517-b859-d6061956784f', 'version': 1}


### PR DESCRIPTION
Pull metadata keys from KBaseSets.SampleSet object, if they exist. This saves a potentially expensive query for the `get_sampleset_meta` method, which populates the filter_samplesets dropdown.